### PR TITLE
Fix image flag is required for non-interactive mode

### DIFF
--- a/src/commands/chat/channel/create.js
+++ b/src/commands/chat/channel/create.js
@@ -11,7 +11,7 @@ class ChannelCreate extends Command {
 		const { flags } = this.parse(ChannelCreate);
 
 		try {
-			if (!flags.channel || !flags.type || !flags.image) {
+			if (!flags.channel || !flags.type) {
 				const res = await prompt([
 					{
 						type: 'input',


### PR DESCRIPTION
Image is an optional flag, but not providing it (and providing all required flags) still brings up the interactive mode.