### PR TITLE
Fix exit for debug token

### DIFF
--- a/src/commands/debug/token.js
+++ b/src/commands/debug/token.js
@@ -32,7 +32,7 @@ class DebugToken extends Command {
 
 			if (flags.json) {
 				this.log(JSON.stringify(decoded));
-				this.exit(0);
+				return;
 			}
 
 			const table = new Table();
@@ -53,7 +53,6 @@ class DebugToken extends Command {
 			);
 
 			this.log(table.toString());
-			this.exit(0);
 		} catch (error) {
 			this.error('Malformed JWT token or Stream API secret.', {
 				exit: 1


### PR DESCRIPTION
On success, `EEXIT` error with `exit:0` is thrown so correct output is written and logged as error.

Updated logic only on `debug:token` command, probably other commands also need to be updated accordingly.

Related to https://github.com/GetStream/stream-chat-js/issues/313