### PR TITLE
fix(channel): promote_moderator cmd doesn't respect command line flag

### DIFF
--- a/src/commands/chat/channel/promote_moderator.js
+++ b/src/commands/chat/channel/promote_moderator.js
@@ -9,7 +9,7 @@ class ChannelPromoteModerator extends Command {
 		const { flags } = this.parse(ChannelPromoteModerator);
 
 		try {
-			if (!flags.channel || !flags.type || !flags.image) {
+			if (!flags.channel || !flags.type || !flags.user) {
 				const res = await prompt([
 					{
 						type: 'input',


### PR DESCRIPTION
we had an issue with the `promote_moderator` command. Issue described [here](https://github.com/GetStream/stream-cli/issues/55).

the `image` flag seems useless here, and I replaced it with the `user` flag.

fixes #55 