### PR TITLE
Rename users flag in add_member command

### DIFF
--- a/src/commands/chat/channel/add_member.js
+++ b/src/commands/chat/channel/add_member.js
@@ -97,7 +97,7 @@ ChannelAddMember.flags = {
 		description: 'URL to channel image.',
 		required: false
 	}),
-	users: flags.string({
+	user: flags.string({
 		char: 'u',
 		description: 'Unique identifier for the user you are adding.',
 		required: false


### PR DESCRIPTION
There was a difference between the described flags and the actual implementation. While the list of flags accepted a `users` flag, the code actually checked for a `user` flag. Seeing that the business logic seems to handle only one user, I renamed the flag to `user`.