### PR TITLE
docs: raise more eyes to the import docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -124,7 +124,7 @@ In order to initialize the CLI, it's as simple as:
 
 # 📃 Use cases and examples
 
-A couple of example use cases can be found [here](./use_cases.md).
+A couple of example use cases can be found [here](./use_cases.md). We've also created a separate documentation [for the import feature](./stream-cli_chat_imports.md).
 
 # 🚨 Warning
 


### PR DESCRIPTION
Apparently it's too hidden, so let's mention it in the main page.

<img width="440" alt="image" src="https://user-images.githubusercontent.com/19969687/169093744-8c4fad0b-87fc-4971-a9e4-3c2b764a39d8.png">
