### PR TITLE
print json to stdout instead of stderr

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -1,6 +1,8 @@
 package root
 
 import (
+	"os"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
@@ -40,6 +42,8 @@ func NewCmd() *cobra.Command {
 	)
 
 	cobra.OnInitialize(config.GetInitConfig(root, cfgPath))
+
+	root.SetOut(os.Stdout)
 
 	return root
 }


### PR DESCRIPTION
By default cobra's Println writes to stderr. 
This is especially useful when piping the output to less and jq etc.