### PR TITLE
Update version.go to 1.7.2

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,7 +7,7 @@ import (
 const (
 	versionMajor = 1
 	versionMinor = 7
-	versionPatch = 1
+	versionPatch = 2
 )
 
 func FmtVersion() string {


### PR DESCRIPTION
versionPatch was not updated on the latest release.

as a result, stream-cli --version was incorrectly returning 1.7.1 instead of 1.7.2