### PR TITLE
Update user.go

### DIFF
--- a/pkg/cmd/chat/user/user.go
+++ b/pkg/cmd/chat/user/user.go
@@ -170,8 +170,8 @@ func updatePartialCmd() *cobra.Command {
 	}
 
 	fl := cmd.Flags()
-	fl.StringP("user-id", "i", "", "[required] Channel ID")
-	fl.StringP("set", "s", "", "[optional] Raw JSON of key-value pairs to set")
+	fl.StringP("user-id", "i", "", "[required] User ID")
+	fl.StringP("set", "s", "", "[required] Raw JSON of key-value pairs to set")
 	fl.StringP("unset", "u", "", "[optional] Comma separated list of properties to unset")
 	_ = cmd.MarkFlagRequired("user-id")
 


### PR DESCRIPTION
Fixed typo in --user-id 

Updated set flag to required since an unset command without a set command fails with ```Error: unexpected end of JSON input```.

example:

```
stream-cli chat update-user-partial --user-id SAMPLE_USER_ID -u username
```
outputs:
```
Error: unexpected end of JSON input
```

```
stream-cli chat update-user-partial --user-id SAMPLE_USER_ID --set {} -u username
```
outputs:
```
Successfully updated user [SAMPLE_USER_ID]
```