### PR TITLE
Add list-members feature.

### DIFF
--- a/docs/stream-cli_chat_list-members.md
+++ b/docs/stream-cli_chat_list-members.md
@@ -1,4 +1,4 @@
-## `stream-cli chat list-members`
+## stream-cli chat list-members
 
 List members of a channel
 
@@ -6,13 +6,13 @@ List members of a channel
 
 List and paginate members of a channel using the Stream Chat API.
 
-This command supports optional filters, offset/limit for pagination, and sort fields (e.g. `user_id`, `created_at`).
+This command supports optional filters, offset/limit for pagination,
+and sort fields (e.g. "user_id", "created_at").
+
 
 ```
 stream-cli chat list-members --type [channel-type] --id [channel-id] [flags]
 ```
-
----
 
 ### Examples
 
@@ -28,34 +28,30 @@ $ stream-cli chat list-members --type messaging --id red-team --offset 10 --limi
 
 # Sort members by user_id ascending
 $ stream-cli chat list-members --type messaging --id red-team --sort user_id:1
-```
 
----
+```
 
 ### Options
 
 ```
-  -f, --filter string          [optional] JSON string to filter members
+      --filter string          [optional] JSON string to filter members
   -h, --help                   help for list-members
   -i, --id string              [required] Channel ID
-      --limit int              [optional] Pagination limit (default 10)
+      --limit int              [optional] Pagination limit (default 10) (default 10)
       --offset int             [optional] Pagination offset (default 0)
+  -o, --output-format string   [optional] Output format. Can be json or tree (default "json")
       --sort string            [optional] Sorting field and direction (e.g., user_id:1 or created_at:-1)
   -t, --type string            [required] Channel type such as 'messaging' or 'livestream'
-  -o, --output-format string   [optional] Output format. Can be json or tree (default "json")
 ```
-
----
 
 ### Options inherited from parent commands
 
 ```
-      --app string        [optional] Application name to use as it's defined in the configuration file
-      --config string     [optional] Explicit config file path
+      --app string      [optional] Application name to use as it's defined in the configuration file
+      --config string   [optional] Explicit config file path
 ```
-
----
 
 ### SEE ALSO
 
-* [stream-cli chat](stream-cli_chat.md) – Allows you to interact with your Chat applications
+* [stream-cli chat](stream-cli_chat.md)	 - Allows you to interact with your Chat applications
+

--- a/docs/stream-cli_chat_list-members.md
+++ b/docs/stream-cli_chat_list-members.md
@@ -1,0 +1,61 @@
+## `stream-cli chat list-members`
+
+List members of a channel
+
+### Synopsis
+
+List and paginate members of a channel using the Stream Chat API.
+
+This command supports optional filters, offset/limit for pagination, and sort fields (e.g. `user_id`, `created_at`).
+
+```
+stream-cli chat list-members --type [channel-type] --id [channel-id] [flags]
+```
+
+---
+
+### Examples
+
+```
+# List first 10 members of 'red-team'
+$ stream-cli chat list-members --type messaging --id red-team
+
+# Filter members whose name includes 'tom'
+$ stream-cli chat list-members --type messaging --id red-team --filter '{"name":{"$q":"tom"}}'
+
+# Get next page of members (10 offset)
+$ stream-cli chat list-members --type messaging --id red-team --offset 10 --limit 10
+
+# Sort members by user_id ascending
+$ stream-cli chat list-members --type messaging --id red-team --sort user_id:1
+```
+
+---
+
+### Options
+
+```
+  -f, --filter string          [optional] JSON string to filter members
+  -h, --help                   help for list-members
+  -i, --id string              [required] Channel ID
+      --limit int              [optional] Pagination limit (default 10)
+      --offset int             [optional] Pagination offset (default 0)
+      --sort string            [optional] Sorting field and direction (e.g., user_id:1 or created_at:-1)
+  -t, --type string            [required] Channel type such as 'messaging' or 'livestream'
+  -o, --output-format string   [optional] Output format. Can be json or tree (default "json")
+```
+
+---
+
+### Options inherited from parent commands
+
+```
+      --app string        [optional] Application name to use as it's defined in the configuration file
+      --config string     [optional] Explicit config file path
+```
+
+---
+
+### SEE ALSO
+
+* [stream-cli chat](stream-cli_chat.md) – Allows you to interact with your Chat applications

--- a/pkg/cmd/chat/channel/channel_test.go
+++ b/pkg/cmd/chat/channel/channel_test.go
@@ -204,3 +204,27 @@ func TestHideAndShowChannel(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, cmd.OutOrStdout().(*bytes.Buffer).String(), "Successfully shown channel")
 }
+
+func TestListMembers(t *testing.T) {
+	cmd := test.GetRootCmdWithSubCommands(NewCmds()...)
+	ch := test.InitChannel(t)
+	u := test.CreateUser()
+	t.Cleanup(func() {
+		test.DeleteChannel(ch)
+		test.DeleteUser(u)
+	})
+
+	// Add member so they show up in the member list
+	cmd.SetArgs([]string{"add-members", "-t", "messaging", "-i", ch, u})
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+
+	// Now list members
+	cmd.SetArgs([]string{"list-members", "-t", "messaging", "-i", ch})
+	_, err = cmd.ExecuteC()
+	require.NoError(t, err)
+
+	// Assert the user ID is in the output
+	out := cmd.OutOrStdout().(*bytes.Buffer).String()
+	require.Contains(t, out, u)
+}


### PR DESCRIPTION
Add list-members Command

Adds a new chat list-members command to list and paginate channel members via the Stream Chat API. Supports filtering, sorting, and pagination. Includes test coverage and generated CLI docs.