### PR TITLE
Add unmute-channel feature.

### DIFF
--- a/docs/stream-cli_chat_unmute-channel.md
+++ b/docs/stream-cli_chat_unmute-channel.md
@@ -1,0 +1,38 @@
+## stream-cli chat unmute-channel
+
+Unmute a channel for a user
+
+```
+stream-cli chat unmute-channel --type [channel-type] --id [channel-id] --user-id [user-id] [flags]
+```
+
+### Synopsis
+
+Unmutes a previously muted channel for a specific user.
+
+### Examples
+
+```
+# Unmute the 'redteam' channel for user 'john'
+$ stream-cli chat unmute-channel --type messaging --id redteam --user-id john
+```
+
+### Options
+
+```
+  -t, --type string        [required] Channel type such as 'messaging'
+  -i, --id string          [required] Channel ID
+  -u, --user-id string     [required] User ID
+  -h, --help               help for unmute-channel
+```
+
+### Options inherited from parent commands
+
+```
+      --app string      [optional] Application name to use as it's defined in the configuration file
+      --config string   [optional] Explicit config file path
+```
+
+### SEE ALSO
+
+* [stream-cli chat](stream-cli_chat.md)	 - Allows you to interact with your Chat applications

--- a/docs/stream-cli_chat_unmute-channel.md
+++ b/docs/stream-cli_chat_unmute-channel.md
@@ -2,28 +2,30 @@
 
 Unmute a channel for a user
 
-```
-stream-cli chat unmute-channel --type [channel-type] --id [channel-id] --user-id [user-id] [flags]
-```
-
 ### Synopsis
 
 Unmutes a previously muted channel for a specific user.
+
+
+```
+stream-cli chat unmute-channel --type [channel-type] --id [channel-id] --user-id [user-id] [flags]
+```
 
 ### Examples
 
 ```
 # Unmute the 'redteam' channel for user 'john'
 $ stream-cli chat unmute-channel --type messaging --id redteam --user-id john
+
 ```
 
 ### Options
 
 ```
-  -t, --type string        [required] Channel type such as 'messaging'
-  -i, --id string          [required] Channel ID
-  -u, --user-id string     [required] User ID
-  -h, --help               help for unmute-channel
+  -h, --help             help for unmute-channel
+  -i, --id string        [required] Channel ID
+  -t, --type string      [required] Channel type such as 'messaging'
+  -u, --user-id string   [required] User ID
 ```
 
 ### Options inherited from parent commands
@@ -36,3 +38,4 @@ $ stream-cli chat unmute-channel --type messaging --id redteam --user-id john
 ### SEE ALSO
 
 * [stream-cli chat](stream-cli_chat.md)	 - Allows you to interact with your Chat applications
+

--- a/pkg/cmd/chat/channel/channel.go
+++ b/pkg/cmd/chat/channel/channel.go
@@ -28,6 +28,7 @@ func NewCmds() []*cobra.Command {
 		assignRoleCmd(),
 		hideCmd(),
 		showCmd(),
+		unmuteChannelCmd(),
 	}
 }
 
@@ -604,6 +605,50 @@ func showCmd() *cobra.Command {
 	fl.StringP("type", "t", "", "[required] Channel type such as 'messaging' or 'livestream'")
 	fl.StringP("id", "i", "", "[required] Channel id")
 	fl.StringP("user-id", "u", "", "[required] User id to show the channel to")
+	_ = cmd.MarkFlagRequired("type")
+	_ = cmd.MarkFlagRequired("id")
+	_ = cmd.MarkFlagRequired("user-id")
+
+	return cmd
+}
+
+func unmuteChannelCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unmute-channel --type [channel-type] --id [channel-id] --user-id [user-id]",
+		Short: "Unmute a channel for a user",
+		Long: heredoc.Doc(`
+			Unmutes a previously muted channel for a specific user.
+		`),
+		Example: heredoc.Doc(`
+			# Unmute the 'redteam' channel for user 'john'
+			$ stream-cli chat unmute-channel --type messaging --id redteam --user-id john
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := config.GetConfig(cmd).GetClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			typ, _ := cmd.Flags().GetString("type")
+			id, _ := cmd.Flags().GetString("id")
+			user, _ := cmd.Flags().GetString("user-id")
+
+			ch := client.Channel(typ, id)
+			_, err = ch.Unmute(cmd.Context(), user)
+			if err != nil {
+				return err
+			}
+
+			cmd.Printf("Successfully unmuted channel [%s] for user [%s]\n", id, user)
+			return nil
+		},
+	}
+
+	fl := cmd.Flags()
+	fl.StringP("type", "t", "", "[required] Channel type such as 'messaging'")
+	fl.StringP("id", "i", "", "[required] Channel ID")
+	fl.StringP("user-id", "u", "", "[required] User ID")
+
 	_ = cmd.MarkFlagRequired("type")
 	_ = cmd.MarkFlagRequired("id")
 	_ = cmd.MarkFlagRequired("user-id")


### PR DESCRIPTION
This PR adds a new unmute-channel command to the CLI, allowing users to unmute a specific channel.

Includes:

- New unmute-channel command
- Markdown documentation (docs/stream-cli_chat_unmute-channel.md)
- Integration test `TestUnmuteChannel` for validation