### PR TITLE
Add update-message feature.

### DIFF
--- a/docs/stream-cli_chat_update-message.md
+++ b/docs/stream-cli_chat_update-message.md
@@ -1,0 +1,34 @@
+## stream-cli chat update-message
+
+Update an existing message
+
+```
+stream-cli chat update-message --message-id [id] --user [user-id] --text [text]
+```
+
+### Examples
+
+```
+# Update a message by ID
+$ stream-cli chat update-message --message-id msgid-123 --user user123 --text "Updated message text"
+```
+
+### Options
+
+```
+  -h, --help             help for update-message
+      --message-id id    [required] Message ID to update
+      --user string      [required] User ID performing the update
+      --text string      [required] New message text
+```
+
+### Options inherited from parent commands
+
+```
+      --app string      [optional] Application name to use as it's defined in the configuration file
+      --config string   [optional] Explicit config file path
+```
+
+### SEE ALSO
+
+* [stream-cli chat](stream-cli_chat.md)	 - Allows you to interact with your Chat applications

--- a/docs/stream-cli_chat_update-message.md
+++ b/docs/stream-cli_chat_update-message.md
@@ -2,8 +2,14 @@
 
 Update an existing message
 
+### Synopsis
+
+Update a message by providing the message ID, user ID, and new message text.
+This fully overwrites the message content while preserving metadata.
+
+
 ```
-stream-cli chat update-message --message-id [id] --user [user-id] --text [text]
+stream-cli chat update-message --message-id [id] --user [user-id] --text [text] [flags]
 ```
 
 ### Examples
@@ -11,15 +17,16 @@ stream-cli chat update-message --message-id [id] --user [user-id] --text [text]
 ```
 # Update a message by ID
 $ stream-cli chat update-message --message-id msgid-123 --user user123 --text "Updated message text"
+
 ```
 
 ### Options
 
 ```
-  -h, --help             help for update-message
-      --message-id id    [required] Message ID to update
-      --user string      [required] User ID performing the update
-      --text string      [required] New message text
+  -h, --help                help for update-message
+      --message-id string   [required] ID of the message to update
+      --text string         [required] New message text
+      --user string         [required] User ID performing the update
 ```
 
 ### Options inherited from parent commands
@@ -32,3 +39,4 @@ $ stream-cli chat update-message --message-id msgid-123 --user user123 --text "U
 ### SEE ALSO
 
 * [stream-cli chat](stream-cli_chat.md)	 - Allows you to interact with your Chat applications
+


### PR DESCRIPTION
This PR adds a new `update-message` command to the CLI, allowing users to truncate a specific channel.

Includes:

- New `update-message` command
- Markdown documentation (docs/stream-cli_chat_update-message.md)
- Integration test `TestUpdateMessage` for validation