### PR TITLE
Replace deprecated SendReaction and DeleteReaction methods

### DIFF
--- a/pkg/cmd/chat/reaction/reaction.go
+++ b/pkg/cmd/chat/reaction/reaction.go
@@ -73,8 +73,7 @@ func sendCmd() *cobra.Command {
 			userID, _ := cmd.Flags().GetString("user-id")
 
 			r := &stream_chat.Reaction{Type: reactionType}
-
-			_, err = c.Channel("", "").SendReaction(cmd.Context(), r, msgID, userID)
+			_, err = c.SendReaction(cmd.Context(), r, msgID, userID)
 			if err != nil {
 				return err
 			}
@@ -113,7 +112,7 @@ func deleteCmd() *cobra.Command {
 			userID, _ := cmd.Flags().GetString("user-id")
 			msgID, _ := cmd.Flags().GetString("message-id")
 
-			_, err = c.Channel("", "").DeleteReaction(cmd.Context(), msgID, reactionType, userID)
+			_, err = c.DeleteReaction(cmd.Context(), msgID, reactionType, userID)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Replaced the deprecated `Channel.SendReaction` and `DeleteReaction` method with the updated `SendReaction` method to align with the latest SDK changes.

Details
- Updated method calls to prevent future deprecation issues.
- Verified that all affected functionalities behave as expected.

Testing
All unit and integration tests passed successfully.
```
=== RUN   TestReactions
--- PASS: TestReactions (5.10s)
PASS

Process finished with the exit code 0
```